### PR TITLE
Ajusta caminho dos arquivos do processo de migração do banco de dados

### DIFF
--- a/server/ormconfig.json
+++ b/server/ormconfig.json
@@ -2,8 +2,8 @@
   "name": "default",
   "type": "sqlite",
   "database": "coiner.db",
-  "entities": ["./src/**/*.entity.{ts,js}"],
-  "migrations": ["./src/migrations/*.ts"],
+  "entities": ["./dist/**/*.entity.js"],
+  "migrations": ["./dist/migrations/*.js"],
   "cli": {
     "migrationsDir": "./src/migrations"
   }

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -11,7 +11,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'coiner.db',
-      entities: [__dirname + '/../**/*.entity.js'],
+      entities: ['dist/**/*.entity.js'],
     }),
   ],
   controllers: [AppController],


### PR DESCRIPTION
Tive este erro ao executar o projeto `server`, vi que isto ocorre pois os arquivos de migração do banco de dados incluem arquivos _TypeScript_. Porém o _runtime_ executado no processo de migração é o do Node sem suporte à módulos ESM, causando o erro de sintaxe.

Ajustei os caminhos das _migrations_ para rodarem a partir dos arquivos buildados pelo TypeScript 😃 

![image](https://user-images.githubusercontent.com/13911440/120865094-ba1f9c00-c563-11eb-9a3f-577900a21fb5.png)
